### PR TITLE
feat!: add cli with config management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ alpha-zero = { path = "alpha-zero" }
 atomic_float = { version = "0.1" }
 bincode = { version = "1" }
 bitvec = { version = "1" }
+clap = "4.3.19"
 environment = { path = "environment" }
 mcts = { path = "mcts" }
 network-utils = { path = "network-utils" }
@@ -20,6 +21,7 @@ rayon = { version = "1.7" }
 serde = { version = "1", features = ["derive"] }
 tensorflow = { version = "0.20", features = ["tensorflow_gpu"] }
 thiserror = { version = "1" }
+toml = "0.7.6"
 
 [workspace]
 members = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,98 @@
+use serde::{Deserialize,Serialize};
+
+use std::{
+    fs,
+    path::Path,
+    default::Default,
+};
+
+use toml;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub parameters: Parameters,
+    //pub enviroment: Enviroment,    // TODO: implement enviroment or make it separate from the
+                                     //       config file
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Parameters {
+    // Trainer Parameters
+    pub model_name: String,
+    pub replay_memory_size: usize,
+    pub episode_count: usize,
+    pub evaluate_count: usize,
+    pub evaluate_batch_size: usize,
+    pub training_count: usize,
+    pub training_batch_size: usize,
+    pub test_evaluate_count: usize,
+    pub temperature: f32,
+    pub temperature_threshold: usize,
+
+    //Plot Parameters
+    pub max_losses: usize,
+}
+
+impl Config {
+    pub fn new(name: &str) -> Self {
+        let path_base = Path::new("config");
+        let path_file = path_base.join(name.to_owned() + ".toml");
+
+        if !path_base.exists() {
+            fs::create_dir_all(path_base).unwrap();
+        }
+        if !path_file.exists() {
+            Self::save(path_file.to_str().unwrap().to_string()).unwrap();
+        }
+            
+        match Self::load(path_file.to_str().unwrap().to_string()){
+            Ok(_config) => _config,
+            Err(_e) => {
+                println!("Error loading config, Fallback to default");
+                Self::default()
+            }
+        }
+    } 
+    pub fn load(path: String) -> Result<Self, std::io::Error> {
+        let path = Path::new(&path);
+
+        let contents = fs::read_to_string(path)?;
+        let config = toml::from_str(&contents).unwrap();
+        Ok(config)
+    }
+    pub fn save(path: String) -> Result<(), std::io::Error> {
+        let path = Path::new(&path);
+
+        let contents = toml::to_string(&Config::default()).unwrap();
+        fs::write(path, contents)?;
+        Ok(()) 
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            parameters: Parameters::default(),
+        }
+    }
+}
+impl Default for Parameters {
+    fn default() -> Parameters
+    {
+        Parameters {
+            model_name: "alpha-zero".to_owned(),
+            replay_memory_size: 600_000,
+            episode_count: 50,
+            evaluate_count: 600,
+            evaluate_batch_size: 16,
+            training_count: 600,
+            training_batch_size: 128,
+            test_evaluate_count: 800,
+            temperature: 1.0,
+            temperature_threshold: 30,
+
+            max_losses: 1024 * 1024,
+        }
+    }
+}
+ 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,14 +8,14 @@ use std::{
 
 use toml;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     pub parameters: Parameters,
     //pub enviroment: Enviroment,    // TODO: implement enviroment or make it separate from the
                                      //       config file
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Parameters {
     // Trainer Parameters
     pub model_name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,29 @@
 mod plot;
 mod trainer;
 mod utils;
+mod config;
 
 use tensorflow::Status;
 use trainer::Trainer;
+use clap::{Arg,Command};
+
+fn cli() -> Command {
+    Command::new("omok-ai")
+        .arg(
+            Arg::new("config")
+                .help("Name of the config file")
+                .short('c')
+                .long("config")
+                .default_value("default"),
+        )
+}
 
 fn main() -> Result<(), Status> {
+    let args = cli().get_matches();
     let mut train = Trainer::new()?;
+
+    let config_name = args.get_one::<String>("config").unwrap();
+    let config = config::Config::new(config_name);
     train.train(10_000)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,10 @@ fn cli() -> Command {
 
 fn main() -> Result<(), Status> {
     let args = cli().get_matches();
-    let mut train = Trainer::new()?;
-
     let config_name = args.get_one::<String>("config").unwrap();
-    let config = config::Config::new(config_name);
+        
+    let mut train = Trainer::new(config_name)?;
+
     train.train(10_000)?;
     Ok(())
 }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -21,19 +21,20 @@ pub enum PlotError {
 
 pub struct Plotter {
     losses: VecDeque<(f32, f32, f32)>,
+    max_losses: usize,
 }
 
 impl Plotter {
-    pub const MAX_LOSSES: usize = 1024 * 1024;
 
-    pub fn new() -> Self {
+    pub fn new(max_losses: usize) -> Self {
         Self {
             losses: VecDeque::new(),
+            max_losses,
         }
     }
 
     pub fn add_loss(&mut self, loss: (f32, f32, f32)) {
-        if self.losses.len() == Self::MAX_LOSSES {
+        if self.losses.len() == self.max_losses {
             self.losses.pop_front();
         }
 


### PR DESCRIPTION
When using by cargo run, you need `--` for passing the -c argument

example:
```
omok-ai -c test

or

cargo run -- -c test
```

When there is no argument it falls back to default
While if there is no default.toml, it generates itself